### PR TITLE
fix: set ci job names

### DIFF
--- a/.github/workflows/base-ci.yml
+++ b/.github/workflows/base-ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   lint-fmt:
+    name: "Lint and Format"
     runs-on: ubuntu-latest
     
     steps:
@@ -25,6 +26,7 @@ jobs:
       run: make fmt
 
   build:
+    name: "Build"
     runs-on: ubuntu-latest
     
     steps:

--- a/.github/workflows/base-ci.yml
+++ b/.github/workflows/base-ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint-fmt:
-    name: "Lint and Format"
+    name: Lint and Format
     runs-on: ubuntu-latest
     
     steps:
@@ -26,7 +26,7 @@ jobs:
       run: make fmt
 
   build:
-    name: "Build"
+    name: Build
     runs-on: ubuntu-latest
     
     steps:

--- a/.github/workflows/migrations-ci.yml
+++ b/.github/workflows/migrations-ci.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   migrations:
+    name: Migrations
     runs-on: ubuntu-latest
               
     steps:


### PR DESCRIPTION
This PR sets up the Job Names for each CI Job as this is necessary to enforce the GitHub Status Checks before merging